### PR TITLE
MN-333: upgrade @wert-io/widget-initializer to version 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wert-io/widget-initializer": "7.0.1"
+        "@wert-io/widget-initializer": "7.0.2"
       },
       "devDependencies": {
         "@types/react": "18.0.9",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.1.tgz",
-      "integrity": "sha512-/0IYjYFo2iVXGNC47HGQ7uGMJ4pxpue7Zr8obJnSHc3CfqlmMPXMAcZBg+0b6SM3qT3sShOIIqmn/GgCeIcrbg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
+      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q==",
       "license": "ISC"
     },
     "node_modules/@yarn-tool/resolve-package": {
@@ -3731,9 +3731,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.1.tgz",
-      "integrity": "sha512-/0IYjYFo2iVXGNC47HGQ7uGMJ4pxpue7Zr8obJnSHc3CfqlmMPXMAcZBg+0b6SM3qT3sShOIIqmn/GgCeIcrbg=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
+      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q=="
     },
     "@yarn-tool/resolve-package": {
       "version": "1.0.47",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/module-react-component",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/module-react-component",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "@wert-io/widget-initializer": "7.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/module-react-component",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "WertModule React component",
   "author": "@wert-io",
   "main": "dist/wert-module.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/wert-module.d.ts",
   "license": "ISC",
   "dependencies": {
-    "@wert-io/widget-initializer": "7.0.1"
+    "@wert-io/widget-initializer": "7.0.2"
   },
   "devDependencies": {
     "@types/react": "18.0.9",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only bump plus a patch version increment; risk is limited to any behavioral changes introduced by `@wert-io/widget-initializer@7.0.2`.
> 
> **Overview**
> Updates this package version from `5.0.0` to `5.0.1`.
> 
> Upgrades the `@wert-io/widget-initializer` dependency from `7.0.1` to `7.0.2`, updating `package.json` and `package-lock.json` (including the resolved tarball/integrity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e700fc4bb074121277d3c87a12037a63a31aa2d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->