### PR TITLE
MN-370 Upgrade widget-initializer to 7.0.3 in corresponding projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
-        "@wert-io/widget-initializer": "7.0.2"
+        "@wert-io/widget-initializer": "7.0.3"
       },
       "devDependencies": {
         "@types/react": "18.0.9",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
-      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
+      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg==",
       "license": "ISC"
     },
     "node_modules/@yarn-tool/resolve-package": {
@@ -3731,9 +3731,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.2.tgz",
-      "integrity": "sha512-L7PyITRV3x/hF8nuKA3LmVkKAuW5C30ZW4VvOUCVKWc1evEkY/cgtGqDG64ogTk6qED433tWOqaLIFFfvUlZ3Q=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
+      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg=="
     },
     "@yarn-tool/resolve-package": {
       "version": "1.0.47",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/module-react-component",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/module-react-component",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
         "@wert-io/widget-initializer": "7.0.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/wert-module.d.ts",
   "license": "ISC",
   "dependencies": {
-    "@wert-io/widget-initializer": "7.0.2"
+    "@wert-io/widget-initializer": "7.0.3"
   },
   "devDependencies": {
     "@types/react": "18.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/module-react-component",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "WertModule React component",
   "author": "@wert-io",
   "main": "dist/wert-module.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch dependency and package version bump with lockfile refresh only; no runtime code changes in the diff.
> 
> **Overview**
> Bumps **`@wert-io/widget-initializer`** from **7.0.2** to **7.0.3** and publishes **`@wert-io/module-react-component`** as **5.0.2** so this React wrapper stays aligned with the updated initializer (MN-370).
> 
> The diff only touches **`package.json`** and **`package-lock.json`**; there are no changes to component or hook source in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e704bb488ef9b34247c7075485436e565217cfa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->