### PR TITLE
DEVS-10057 Upgrade widget-initializer to 7.0.5 in corresponding projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/module-react-component",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/module-react-component",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "ISC",
       "dependencies": {
         "@wert-io/widget-initializer": "7.0.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.3",
       "license": "ISC",
       "dependencies": {
-        "@wert-io/widget-initializer": "7.0.3"
+        "@wert-io/widget-initializer": "7.0.5"
       },
       "devDependencies": {
         "@types/react": "18.0.9",
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@wert-io/widget-initializer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
-      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.5.tgz",
+      "integrity": "sha512-Gaed1AmHScYMfZ7T+bAkywueVnOdGkdefFJF+0Zpw2aleFPjJCRXCHUfPDBiOz/9OKGaorHpIETKSirJOOUisw==",
       "license": "ISC"
     },
     "node_modules/@yarn-tool/resolve-package": {
@@ -3731,9 +3731,9 @@
       }
     },
     "@wert-io/widget-initializer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.3.tgz",
-      "integrity": "sha512-ww0o0sQxvuslSLyA4OA42fwmlShF3PI5HxjwP10N2NO17PzQHp0qRhkCiT7zpje1bgHTs7Z9pDG+U2Hot/S0Xg=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@wert-io/widget-initializer/-/widget-initializer-7.0.5.tgz",
+      "integrity": "sha512-Gaed1AmHScYMfZ7T+bAkywueVnOdGkdefFJF+0Zpw2aleFPjJCRXCHUfPDBiOz/9OKGaorHpIETKSirJOOUisw=="
     },
     "@yarn-tool/resolve-package": {
       "version": "1.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/module-react-component",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "WertModule React component",
   "author": "@wert-io",
   "main": "dist/wert-module.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/wert-module.d.ts",
   "license": "ISC",
   "dependencies": {
-    "@wert-io/widget-initializer": "7.0.3"
+    "@wert-io/widget-initializer": "7.0.5"
   },
   "devDependencies": {
     "@types/react": "18.0.9",
@@ -30,7 +30,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "start": "rollup -c -w"
+    "start": "rollup -c -w",
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Task id before renaming MN-394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile-only dependency bump plus a standard prepublish build hook; no application source changes in this diff.
> 
> **Overview**
> Bumps **`@wert-io/module-react-component`** from **5.0.3** to **5.0.4** and upgrades the **`@wert-io/widget-initializer`** dependency from **7.0.3** to **7.0.5**, with **`package-lock.json`** updated to match.
> 
> Adds a **`prepublishOnly`** script that runs **`npm run build`** so the **`dist`** output is rebuilt automatically before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41443dfd82d2588d4eaa9d93905bffcf5dee0e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->